### PR TITLE
[release-2.4] Change default port for health-probe-bind-address

### DIFF
--- a/cmd/manager/tool/options.go
+++ b/cmd/manager/tool/options.go
@@ -71,7 +71,7 @@ func ProcessFlags() {
 	flag.StringVar(
 		&Options.ProbeAddr,
 		"health-probe-bind-address",
-		":8081",
+		":8082",
 		"The address the probe endpoint binds to.",
 	)
 }

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -39,13 +39,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8081
+              port: 8082
             failureThreshold: 3
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /readyz
-              port: 8081
+              port: 8082
             failureThreshold: 3
             periodSeconds: 10
       volumes:


### PR DESCRIPTION
To avoid port conflicts when deploying in the same pod

Signed-off-by: Yu Cao <ycao@redhat.com>