### PR TITLE
Change default port for health-probe-bind-address

### DIFF
--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -42,13 +42,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8081
+              port: 8082
             initialDelaySeconds: 15
             periodSeconds: 20
           readinessProbe:
             httpGet:
               path: /readyz
-              port: 8081
+              port: 8082
             initialDelaySeconds: 5
             periodSeconds: 10
       volumes:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -158,14 +158,14 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: 8082
           initialDelaySeconds: 15
           periodSeconds: 20
         name: governance-policy-status-sync
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: 8082
           initialDelaySeconds: 5
           periodSeconds: 10
         securityContext:

--- a/tool/options.go
+++ b/tool/options.go
@@ -88,7 +88,7 @@ func ProcessFlags() {
 	flag.StringVar(
 		&Options.ProbeAddr,
 		"health-probe-bind-address",
-		":8081",
+		":8082",
 		"The address the probe endpoint binds to.",
 	)
 }


### PR DESCRIPTION
Change default port for health-probe-bind-address to
avoid port conflicts when deploying in the same pod

Signed-off-by: Yu Cao <ycao@redhat.com>